### PR TITLE
fix: fix tempo network port bindings

### DIFF
--- a/podman/tempo.yaml
+++ b/podman/tempo.yaml
@@ -18,7 +18,9 @@ distributor:
     otlp:
       protocols:
         http:
+          endpoint: 0.0.0.0:4318
         grpc:
+          endpoint: 0.0.0.0:4317
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally


### PR DESCRIPTION
fix issue #1 , explicitly bind tempo endpoint ports under the distributor.receivers.otlp.protocols

```
distributor:
  receivers:
    otlp:
      protocols:
        http:
          endpoint: 0.0.0.0:4318
        grpc:
          endpoint: 0.0.0.0:4317
```